### PR TITLE
Change link for SPL examples

### DIFF
--- a/samples/index.md
+++ b/samples/index.md
@@ -9,7 +9,7 @@ weight: 1
 
 We have over 100 readily usable examples, from very simple to complex.
 
-To download a copy of these examples:  [SPL Examples for Beginners](https://www.ibm.com/developerworks/community/files/app?lang=en#/collection/ef9f8aa9-240f-4854-aae3-ef3b065791da)
+Download a copy of these examples from the [releases page](https://github.com/IBMStreams/samples/releases) of the samples project.
 
 You may also browse these samples here:
 {% include sampleIndex.html%}


### PR DESCRIPTION
These samples are now hosted in the samples repository on github. The zip file is also available from the releases page of that project.