### PR TITLE
adjust headings to account for top navbar

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -10,3 +10,7 @@ ul.simple {
   list-style: none;
   margin-left: -20px;
 }
+h1, h2, h3, h4 {
+  padding-top: 75px;
+  margin-top: -50px;
+}


### PR DESCRIPTION
In response to request from @ddebrunner noticing in-page headings hidden under top navbar when landing there from following a link.