### PR TITLE
Updated links for Java and Python dev gdes

### DIFF
--- a/docs/4.2/qse-getting-started.markdown
+++ b/docs/4.2/qse-getting-started.markdown
@@ -167,9 +167,9 @@ if __name__ == '__main__':
 
 To get started, follow these development guides:
 
-* [Develop Streams Applications in Java](../../java/java-appapi-devguide)
+* [Develop Streams Applications in Java](http://ibmstreams.github.io/streamsx.documentation/docs/java/java-appapi-devguide/)
 * [Develop Streams Applications in Scala](https://github.com/IBMStreams/streamsx.topology/wiki/Scala-Support)
-* [Develop Streams Applications in Python 1.4](../../python/1.4/python-appapi-devguide)
+* Develop Streams Applications in Python [v1.6](http://ibmstreams.github.io/streamsx.documentation/docs/python/1.6/python-appapi-devguide/) , [v1.4](http://ibmstreams.github.io/streamsx.documentation/docs/python/1.4/python-appapi-devguide/)
 
 
 ### Streams Processing Language (SPL)


### PR DESCRIPTION
Java: 
Old: (../../java/java-appapi-devguide) -> (http://ibmstreams.github.io/streamsx.documentation/docs/java/java-appapi-devguide/)
Python: 
Old: (../../python/1.4/python-appapi-devguide) ->
Two new links:
1.6 link=http://ibmstreams.github.io/streamsx.documentation/docs/python/1.6/python-appapi-devguide/
1.4 link=http://ibmstreams.github.io/streamsx.documentation/docs/python/1.4/python-appapi-devguide/