### PR TITLE
Use correct case for GitHub labels

### DIFF
--- a/_includes/docHeader.html
+++ b/_includes/docHeader.html
@@ -10,7 +10,7 @@
 		</div>
 		<div class="collapse navbar-collapse" id="navbar-main">
 			<ul class="nav navbar-nav">
-				<li><a href="http://ibmstreams.github.io" target="_blank">Github</a>
+				<li><a href="http://ibmstreams.github.io" target="_blank">GitHub</a>
 				</li>
 				<li><a href="https://developer.ibm.com/streamsdev/"
 					target="_blank">Community</a></li>

--- a/docs/4.1/messaging/jms-operators-getting-started.markdown
+++ b/docs/4.1/messaging/jms-operators-getting-started.markdown
@@ -15,7 +15,7 @@ Readers of this article is expected to have basic understanding in JMS and WebSp
 Prior to using JMS operators, the following software must be installed and configured.
 
 -  Streams - a quick start edition VM is available, see the [Installing Streams Quick Start Edition VM Image](http://ibmstreams.github.io/streamsx.documentation//docs/4.1/qse-install-vm/) for more information.
-- Messaging Toolkit - a official version of the toolkit is shipped with  Streams or download it from [IBM Streams Github Messaging Toolkit Repository](https://github.com/IBMStreams/streamsx.messaging)
+- Messaging Toolkit - a official version of the toolkit is shipped with  Streams or download it from [IBM Streams GitHub Messaging Toolkit Repository](https://github.com/IBMStreams/streamsx.messaging)
 - Messaging server and client - JMS operators supports both WebSpehre MQ and ActiveMQ, depending on the target messaging system, install either WebSphere MQ or ActiveMQ. If  Streams is running on a different machine than messaging server, install WebSphere MQ client libraries for Java or ActiveMQ on the same machine where  Streams is running as JMS operators looks up certain jar files from these messaging clients at runtime.
   - WebSphere MQ: a trial version of [WebSphere MQ](https://www-01.ibm.com/marketing/iwm/iwm/web/pick.do?pkgid=&S_SRCID=ESD-WSMQ-EVAL&source=ESD-WSMQ-EVAL&S_TACT=109J84RW&S_PKG=CR9H9ML&lang=en_US&lang=en_US) is available.
   - ActiveMQ: download a supported version of [ActiveMQ](http://activemq.apache.org/download.html)

--- a/docs/4.1/messaging/kafka-operators-getting-started.markdown
+++ b/docs/4.1/messaging/kafka-operators-getting-started.markdown
@@ -18,7 +18,7 @@ Readers of this guide are expected to have a basic understanding of Kafka and IB
 Prior to using Kafka operators, the following software must be installed and configured:
 
 * **IBM Streams** - A <a target="_blank" href="http://ibmstreams.github.io/streamsx.documentation//docs/4.1/qse-install-vm/">Quick Start Edition VM</a> is available for free. This guide assumes that you have a Streams domain and instance up and running. 
-* **Messaging Toolkit 4.0+** - You can download it from the IBM Streams Github Messaging Toolkit Repository <a target="_blank" href="https://github.com/IBMStreams/streamsx.messaging/releases">Release Page</a>.
+* **Messaging Toolkit 4.0+** - You can download it from the IBM Streams GitHub Messaging Toolkit Repository <a target="_blank" href="https://github.com/IBMStreams/streamsx.messaging/releases">Release Page</a>.
 * **Kafka Brokers** - This guide assumes you are using Kafka 0.9 or above. To quickly get a Kafka server up and running, follow <a target="_blank" href="http://kafka.apache.org/documentation.html#quickstart">these directions</a>. 
 
 ## Information to Collect

--- a/docs/4.1/qse-getting-started.markdown
+++ b/docs/4.1/qse-getting-started.markdown
@@ -166,7 +166,7 @@ Below are some resources to help you get started.
 
 Streams is shipped with many toolkits out of the box to enable integration with some of the most popular systems like HDFS, HBase, Kafka, Active MQ and more.  To learn about the set of toolkits that are shipped as part of the Streams product, refer to the [Product Toolkits Overview](https://developer.ibm.com/streamsdev/docs/product-toolkits-overview/)
 
-[IBMStreams on Github](https://github.com/ibmstreams) provides a platform enabling Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on Github, see: [IBM Streams Github Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/)
+[IBMStreams on GitHub](https://github.com/ibmstreams) provides a platform enabling Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on GitHub, see: [IBM Streams GitHub Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/)
 
 ### Integration with IBM InfoSphere Data Governance Catalog
 <div class="alert alert-success" role="alert"><b>New in Streams 4.1!</b>  Integration with the IBM InfoSphere Data Governance Catalog eanbles you to manage and govern your data.</div>
@@ -230,7 +230,7 @@ The following Streams resources can help you connect with the Streams community 
 
 * **[StreamsDev](https://developer.ibm.com/streamsdev/)** - This resource is a developer-to-developer website maintained by the Streams Development Team.  It contains many useful articles and getting started material.  Check back often for new articles, tips and best practises to this website.
 * **[Streams Forum](https://www.ibmdw.net/answers/questions/?community=streamsdev&sort=newest&refine=none)** - This forum enables you to ask, and get answers to your questions, related to IBM Streams. If you have questions, start here.
-* **[IBMStreams on Github](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on Github  contains many open-source toolkits.  For a list of available toolkits available on Github, see this web page:  [IBMStreams Github Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
+* **[IBMStreams on GitHub](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on GitHub  contains many open-source toolkits.  For a list of available toolkits available on GitHub, see this web page:  [IBMStreams GitHub Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
 * **[IBM Streams Support](http://www.ibm.com/support/entry/portal/Overview/Software/Information_Management/InfoSphere_Streams)** - This website provides information about IBM Streams downloads, technical support tools, documentation, and other resources.
 * **[IBM Streams Product Site](http://www.ibm.com/analytics/us/en/technology/stream-computing/)** - This website provides a broad range of information and resources about Streams and related topics.
 

--- a/docs/4.2/messaging/jms-operators-getting-started.markdown
+++ b/docs/4.2/messaging/jms-operators-getting-started.markdown
@@ -16,7 +16,7 @@ Readers of this article is expected to have basic understanding in JMS and WebSp
 Prior to using JMS operators, the following software must be installed and configured.
 
 -  Streams - a quick start edition VM is available, see the [Installing Streams Quick Start Edition VM Image](http://ibmstreams.github.io/streamsx.documentation//docs/4.2/qse-install-vm/) for more information.
-- Messaging Toolkit - a official version of the toolkit is shipped with  Streams or download it from [IBM Streams Github Messaging Toolkit Repository](https://github.com/IBMStreams/streamsx.messaging)
+- Messaging Toolkit - a official version of the toolkit is shipped with  Streams or download it from [IBM Streams GitHub Messaging Toolkit Repository](https://github.com/IBMStreams/streamsx.messaging)
 - Messaging server and client - JMS operators supports both WebSpehre MQ and ActiveMQ, depending on the target messaging system, install either WebSphere MQ or ActiveMQ. If  Streams is running on a different machine than messaging server, install WebSphere MQ client libraries for Java or ActiveMQ on the same machine where  Streams is running as JMS operators looks up certain jar files from these messaging clients at runtime.
   - WebSphere MQ: a trial version of [WebSphere MQ](https://www-01.ibm.com/marketing/iwm/iwm/web/pick.do?pkgid=&S_SRCID=ESD-WSMQ-EVAL&source=ESD-WSMQ-EVAL&S_TACT=109J84RW&S_PKG=CR9H9ML&lang=en_US&lang=en_US) is available.
   - ActiveMQ: download a supported version of [ActiveMQ](http://activemq.apache.org/download.html)

--- a/docs/4.2/messaging/kafka-operators-getting-started.markdown
+++ b/docs/4.2/messaging/kafka-operators-getting-started.markdown
@@ -25,7 +25,7 @@ Readers of this guide are expected to have a basic understanding of Kafka and IB
 Prior to using Kafka operators, the following software must be installed and configured:
 
 * **IBM Streams** - A <a target="_blank" href="http://ibmstreams.github.io/streamsx.documentation//docs/4.2/qse-install-vm/">Quick Start Edition VM</a> is available for free. This guide assumes that you have a Streams domain and instance up and running.
-* **Messaging Toolkit 4.0+** - You can download it from the IBM Streams Github Messaging Toolkit Repository <a target="_blank" href="https://github.com/IBMStreams/streamsx.messaging/releases">Release Page</a>.
+* **Messaging Toolkit 4.0+** - You can download it from the IBM Streams GitHub Messaging Toolkit Repository <a target="_blank" href="https://github.com/IBMStreams/streamsx.messaging/releases">Release Page</a>.
 * **Kafka Brokers** - This guide assumes you are using Kafka 0.9 or above. To quickly get a Kafka server up and running, follow <a target="_blank" href="http://kafka.apache.org/documentation.html#quickstart">these directions</a>.
 
 ## Information to Collect

--- a/docs/4.2/qse-getting-started.markdown
+++ b/docs/4.2/qse-getting-started.markdown
@@ -236,7 +236,7 @@ Below are some resources to help you get started.
 
 Streams is shipped with many toolkits out of the box to enable integration with some of the most popular systems like HDFS, HBase, Kafka, Active MQ and more.  To learn about the set of toolkits that are shipped as part of the Streams product, refer to the [Product Toolkits Overview](https://developer.ibm.com/streamsdev/docs/product-toolkits-overview/)
 
-[IBMStreams on Github](https://github.com/ibmstreams) provides a platform enabling Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on Github, see: [IBM Streams Github Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/)
+[IBMStreams on GitHub](https://github.com/ibmstreams) provides a platform enabling Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on GitHub, see: [IBM Streams GitHub Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/)
 
 ### Integration with IBM InfoSphere Data Governance Catalog
 
@@ -302,7 +302,7 @@ The following Streams resources can help you connect with the Streams community 
 * **[Streamsdev](https://developer.ibm.com/streamsdev/)** - This resource is a developer-to-developer website maintained by the Streams Development Team.  It contains many useful articles and getting started material.  Check back often for new articles, tips and best practises to this website.
 * **[Streams Tutorials Hub](http://ibmstreams.github.io/tutorials/)** A collection of available tutorials, labs and courses.
 * **[Streams Forum](https://www.ibmdw.net/answers/questions/?community=streamsdev&sort=newest&refine=none)** - This forum enables you to ask, and get answers to your questions, related to IBM Streams. If you have questions, start here.
-* **[IBMStreams on Github](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on Github  contains many open-source toolkits.  For a list of available toolkits available on Github, see this web page:  [IBMStreams Github Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
+* **[IBMStreams on GitHub](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on GitHub  contains many open-source toolkits.  For a list of available toolkits available on GitHub, see this web page:  [IBMStreams GitHub Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
 * **[IBM Streams Support](http://www.ibm.com/support/entry/portal/Overview/Software/Information_Management/InfoSphere_Streams)** - This website provides information about IBM Streams downloads, technical support tools, documentation, and other resources.
 * **[IBM Streams Product Site](http://www.ibm.com/analytics/us/en/technology/stream-computing/)** - This website provides a broad range of information and resources about Streams and related topics.
 

--- a/docs/4.3/qse-getting-started.markdown
+++ b/docs/4.3/qse-getting-started.markdown
@@ -165,7 +165,7 @@ Below are some resources to help you get started.
 
 Streams is shipped with many toolkits out of the box to enable integration with some of the most popular systems like HDFS, HBase, Kafka, Active MQ and more.  To learn about the set of toolkits that are shipped as part of the Streams product, refer to the [Product Toolkits Overview](https://developer.ibm.com/streamsdev/docs/product-toolkits-overview/).
 
-[IBMStreams on Github](https://github.com/ibmstreams) provides a platform that enables Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on Github, see: [IBM Streams Github Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
+[IBMStreams on GitHub](https://github.com/ibmstreams) provides a platform that enables Streams to rapidly deliver our support to emgerging technologies to you.  It is also a place for us to share sample applications and helpful utilities.  For a list of open-source projects hosted on GitHub, see: [IBM Streams GitHub Projects Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
 
 ### Integration with IBM InfoSphere Data Governance Catalog
 
@@ -229,7 +229,7 @@ The following Streams resources can help you connect with the Streams community 
 * **[Streamsdev](https://developer.ibm.com/streamsdev/)** - This resource is a developer-to-developer website maintained by the Streams Development Team.  It contains many useful articles and getting started material.  Check back often for new articles, tips and best practises to this website.
 * **[Streams Tutorials Hub](http://ibmstreams.github.io/tutorials/)** A collection of available tutorials, labs and courses.
 * **[Streams Forum](https://www.ibmdw.net/answers/questions/?community=streamsdev&sort=newest&refine=none)** - This forum enables you to ask, and get answers to your questions, related to IBM Streams. If you have questions, start here.
-* **[IBMStreams on Github](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on Github  contains many open-source toolkits.  For a list of available toolkits available on Github, see this web page:  [IBMStreams Github Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
+* **[IBMStreams on GitHub](http://ibmstreams.github.io)** - Streams is shipped with many useful toolkits out of the box.  IBMStreams on GitHub  contains many open-source toolkits.  For a list of available toolkits available on GitHub, see this web page:  [IBMStreams GitHub Toolkits](https://developer.ibm.com/streamsdev/docs/github-projects-overview/).
 * **[IBM Streams Support](http://www.ibm.com/support/entry/portal/Overview/Software/Information_Management/InfoSphere_Streams)** - This website provides information about IBM Streams downloads, technical support tools, documentation, and other resources.
 * **[IBM Streams Product Site](http://www.ibm.com/analytics/us/en/technology/stream-computing/)** - This website provides a broad range of information and resources about Streams and related topics.
 

--- a/docs/_drafts/java-op-dev-guide-outline-sam.markdown
+++ b/docs/_drafts/java-op-dev-guide-outline-sam.markdown
@@ -134,7 +134,7 @@ At this point, I would say we have gone through all the beginner topics.  Next s
 * Reduce function calls in the process method stack
 * Do not copy data
 * How to monitor performance - using metrics view and alerts
-* How to measure performance - may consider putting the FlowCalculator operator as a sample on Github.
+* How to measure performance - may consider putting the FlowCalculator operator as a sample on GitHub.
 * Reference to my document on StreamsDev
 
 ## Java Function Development Guide       

--- a/docs/spl/atom/atom-guide-6-toolkits.markdown
+++ b/docs/spl/atom/atom-guide-6-toolkits.markdown
@@ -54,7 +54,7 @@ Your sample application uses input XML data that was saved in a file. You want t
 
 Instead of reading from a file using a `FileSource` operator, you now need to use the `HTTPGetXMLContent` operator from the [streamsx.inet toolkit](https://github.com/IBMStreams/streamsx.inet) to connect to NextBus.
 
-The toolkit is included in Streams but is developed in the open on GitHub.  So you can download the latest version from Github.
+The toolkit is included in Streams but is developed in the open on GitHub.  So you can download the latest version from GitHub.
 
 
 Step 1: Download and unpack the toolkit

--- a/docs/spl/atom/concepts.md
+++ b/docs/spl/atom/concepts.md
@@ -120,8 +120,8 @@ real-time analytics.
     Reference](http://www-01.ibm.com/support/knowledgecenter/SSCRJU_4.0.0/com.ibm.streams.ref.doc/doc/splstdtlkt-container.html?lang=en)
 -   For a list of available specialized toolkit:  [Product Toolkits
     Overview](https://developer.ibm.com/streamsdev/docs/product-toolkits-overview/)
--   For a list of available open-source specialized toolkit on Github:
-     [Github Projects
+-   For a list of available open-source specialized toolkit on GitHub:
+     [GitHub Projects
     Overview](https://developer.ibm.com/streamsdev/docs/github-projects-overview/)
 
 []{#spl_basics}
@@ -253,8 +253,8 @@ process stock trades from a CSV file.  The application will filter out
 some of the stocks based on ticker names.  It will then calculate the
 average, maximum and minimum ask price for each of the stocks.  The
 results will be written to a file. You may find this example in the
-Samples repository from Github. [TradeApp Sample on
-Github](https://github.com/IBMStreams/samples/tree/master/QuickStart/TradesApp)
+Samples repository from GitHub. [TradeApp Sample on
+GitHub](https://github.com/IBMStreams/samples/tree/master/QuickStart/TradesApp)
 To start writing a Streams application, you must have an understanding
 of the data that you are trying to process.  The csv file that we are
 going to process looks like this.


### PR DESCRIPTION
Fixed cases of `Github` to `GitHub`