### PR TITLE
Move articles from Streamsdev to Java API doc

### DIFF
--- a/_includes/java.md
+++ b/_includes/java.md
@@ -1,0 +1,12 @@
+#### Streams Java Application API 
+Use the Java API to create complete Streams applications using only Java.
+
+- [Java API Development Guide](/streamsx.documentation/docs/java/java-appapi-devguide)
+- [Working with files and other resources](/streamsx.documentation/docs/java/java-appapi-files-in-app-bundle)
+- [Setting parameter values](/streamsx.documentation/docs/java/java-appapi-setting-parameters)
+- [API Reference](https://ibmstreams.github.io/streamsx.topology/doc/javadoc/)
+  
+#### Create a Java Operator 
+
+If you are using SPL, learn how to develop [operators](/streamsx.documentation/docs/spl/quick-start/qs-2/#basic-building-blocks) in Java that can be called from SPL with the [Java Operator Development Guide](/streamsx.documentation/docs/java/java-op-dev-guide).
+

--- a/docs/java/index.markdown
+++ b/docs/java/index.markdown
@@ -6,4 +6,4 @@ weight: 50
 published: true
 ---
 
-{% include nav.html context="/docs/java/"%}
+{% include java.md%}

--- a/docs/java/java-appapi-devguide.markdown
+++ b/docs/java/java-appapi-devguide.markdown
@@ -17,7 +17,15 @@ The primary goals of the Java Application API are to enable the developer to:
 
 Each of these points is covered in further detail in the tutorials on this site and in the example here where we create an application that processes temperature readings from a device.
 
-The Java Application API is fully compatible with IBM Streams version 4.0.0 and later. The API is open source and is available for download from our [streamsx.topology project on GitHub](http://ibmstreams.github.io/streamsx.topology/).
+The Java Application API is fully compatible with IBM Streams version 4.0.0 and later. The API is open source and is available for download from our [streamsx.topology project on GitHub](https://ibmstreams.github.io/streamsx.topology/).
+
+
+## Quick Links
+
+If you are already familiar with the Java Application API, the following pages might prove helpful:
+  - [Working with files and other resources](/streamsx.documentation/docs/java/java-appapi-files-in-app-bundle)
+  - [Setting submission time parameters](/streamsx.documentation/docs/java/java-appapi-setting-parameters)
+
 
 ## Setting up environment
 
@@ -521,7 +529,7 @@ Windows can be used inside of parallel regions. Lastly, Windows can be used insi
 
 Since the applications written with the Java Application API are capable of running on the IBM Streams platform, it's natural that the API would integrate with SPL primitive operators and toolkits. IBM Streams comes with a number of toolkits that provide functionality such as text analysis, HDFS integration, and GeoSpatial processing. Furthermore, if you're currently working with IBM Streams, it's possible that you've implemented your own toolkits that you'd like to utilize.
 
-The purpose of this guide is to demonstrate the basics of interfacing the Java Application API with such toolkits. This is important not only for backward compatibility, but also because it shows that that API can interact with C++ operators in addition to Java ones. Although it isn't assumed that the reader has an understanding of SPL and the structure of toolkits, consulting [the IBM Knowledge Center](http://www-01.ibm.com/support/knowledgecenter/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/creating_toolkits.html?lang=en) may prove informative.
+The purpose of this guide is to demonstrate the basics of interfacing the Java Application API with such toolkits. This is important not only for backward compatibility, but also because it shows that that API can interact with C++ operators in addition to Java ones. Although it isn't assumed that the reader has an understanding of SPL and the structure of toolkits, consulting [the IBM Knowledge Center](https://www-01.ibm.com/support/knowledgecenter/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/creating_toolkits.html?lang=en) may prove informative.
 
 #### Background about Streams Toolkit
 
@@ -529,7 +537,7 @@ Before the Java Application API was released, developing IBM Streams was a two-s
 
 Yet the primitive operators are still very useful. For one thing, many primitive operators are organized into *toolkits* which come packaged with any IBM Streams release to provide tools for machine learning, statistical analysis, and pattern recognition. In addition, since primitive operators can be written in C++, a developer using Java Application API can have certain portions of the application written in C++ if so desired.
 
-In this tutorial, we will not cover [the development of C++ or Java primitive operators](http://www-01.ibm.com/support/knowledgecenter/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/developing_primitive_operators.html?lang=en), however the process for utilizing an already existing toolkit is outlined below.
+In this tutorial, we will not cover [the development of C++ or Java primitive operators](https://www-01.ibm.com/support/knowledgecenter/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/developing_primitive_operators.html?lang=en), however the process for utilizing an already existing toolkit is outlined below.
 
 #### Sample toolkit and operator
 To begin, suppose that we have a 'myTk' toolkit in the home directory. In the 'myTk' toolkit, there is one package named 'myPackageName', and one operator named 'myOperatorName':

--- a/docs/java/java-appapi-files-in-app-bundle.markdown
+++ b/docs/java/java-appapi-files-in-app-bundle.markdown
@@ -1,0 +1,124 @@
+---
+layout: docs
+title:   Using external JARs and files in the Java Application API
+description: Using external resources such as files and archives with the Java API
+weight: 2
+published: true
+---
+
+
+At times, it is necessary to use configuration or static files in your application. For example, if your application reads configuration data from a file, you want that file available at runtime on all the hosts where the application runs. One way to do this is to include the file in the application bundle.
+
+## What is the application bundle?
+
+When you compile a  Streams application, that application is compiled into a file called the **application bundle file**. This is true regardless of the language the application was is written in.  The application bundle file contains all IBM Streams artifacts that are required to execute an application. The application bundle has a `.sab` extension and so is sometimes also called a "sab" file.
+
+
+The Java Application API provides 3 methods for adding external resources to the application bundle:
+ * [Topology.addClassDependency(Class class)](https://ibmstreams.github.io/streamsx.topology/doc/javadoc/com/ibm/streamsx/topology/Topology.html#addClassDependency)
+ * [Topology.addFileDependency(String location, String dstDirName)](https://ibmstreams.github.io/streamsx.topology/doc/javadoc/com/ibm/streamsx/topology/Topology.html#addFileDependency) 
+ * [Topology.addJarDependency(String location)](https://ibmstreams.github.io/streamsx.topology/doc/javadoc/com/ibm/streamsx/topology/Topology.html#addJarDependency) 
+  
+For this blog post, I am going to focus on the last 2 methods: `addFileDependency()` and `addJarDependency()`.
+
+## Adding File Dependencies
+
+There are many operators in the available toolkits that can require a configuration file to be present in the application bundle. For example, when using the HDFS operators from the com.ibm.streamsx.hdfs toolkit, you may want to include a credentials file as part of the application bundle to allow the operators to perform authentication. In this case, you would use the `addFileDependency()` method to ensure the file gets added to the application bundle. 
+
+Using the `addFileDependency()` method does come with some restrictions. First, any files added using this method can only be added to the **etc/** or **opt/** directories within the application bundle. Therefore, you must ensure that the operator parameters are looking in the correct directory when accessing the files. 
+
+Second, adding files to the application bundle using this method are not accessible when using the functional logic. In other words, you would not be able to implement a **com.ibm.streamsx.topology.function.Supplier** that can access files stored in the application bundle. In order to access these files directly, you would need create a proper Java Primitive Operator. To access files stored in the application bundle using the functional logic, the `addJarDependency()` method must be used.
+
+## Adding JAR Dependencies
+
+As mentioned in the previous section, it is not possible to access files stored in the application bundle from functional logic. Any files that need to be accessed from the functional logic should be packaged into a JAR file. The JAR file can then be added to the classpath using the `addJarDependency()` method. Using this method, any functional logic can quickly access the files by accessing the **ClassLoader** and calling one of the `getResource*()` methods available.
+
+
+The following example demonstrates how to create a simple topology application that reads words from a file and prints them to the console. The file 'words.txt' is packaged into a JAR file called 'words.jar'. The JAR file is added to the application classpath using the `addJarDependency()` method (if you are running in Embedded mode, see the "Running Embedded" section below). The source for this sample [can be found here](https://github.com/cancilla/streamsdev/tree/master/FileDepSample).
+
+~~~~ java
+    public class Main {
+
+        public static void main(String[] args) throws Exception {
+
+            Topology t = new Topology("FileDepSample");
+            t.addJarDependency("./words.jar");
+            TStream<String> srcStream = t.source(new FileReader("words.txt"));
+            srcStream.print();
+
+            StreamsContextFactory.getStreamsContext(Type.STANDALONE).submit(t).get();
+        }
+    }
+
+    public class FileReader implements Supplier<Iterable<String>>, Iterable<String>, Iterator<String> {
+        private static final long serialVersionUID = 1L;
+
+        private String filename;
+        private transient BufferedReader reader;
+        private transient String nextLine;
+
+        public FileReader(String filename) {
+            this.filename = filename;
+        }
+
+        private Object readResolve() throws Exception {
+            // read the file contents
+            ClassLoader cl = this.getClass().getClassLoader();
+            InputStream is = cl.getResourceAsStream(this.filename);
+            if(is == null)
+                throw new FileNotFoundException("Unable to find '" + filename + "' in any loaded libraries.");
+
+            reader = new BufferedReader(new InputStreamReader(is));
+            return this;
+
+        }
+
+        @Override
+        public boolean hasNext() {
+            try {
+                return ((nextLine = reader.readLine()) != null);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return false;
+        }
+
+        @Override
+        public String next() {
+            return nextLine;
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return this;
+        }
+
+        @Override
+        public Iterable<String> get() {
+            return this;
+        }
+    }
+~~~~
+
+
+The important stuff happens inside the `readResolve()` method. First, the **ClassLoader** is accessed so that we can get at the JARs that were added to the classpath.
+
+    ClassLoader cl = this.getClass().getClassLoader();
+
+Next, we retrieve the **InputStream** for the file. The **ClassLoader** takes care of figuring out which JAR file contains the 'words.txt'. If the file cannot be found in any of the JARs, then **InputStream** will be `null`.
+
+~~~~ java
+    InputStream is = cl.getResourceAsStream(this.filename);
+    if(is == null)
+      throw new FileNotFoundException("Unable to find '" + filename + "' in any loaded libraries.");
+~~~~
+
+Finally, we create a **BufferedReader** to iterate over each line in the file. Depending on the type of file you are reading, you may need to use a different mechanism to access the contents of the file.
+
+    reader = new BufferedReader(new InputStreamReader(is));
+
+The `next()` and `hasNext()` methods are used to retrieve and return the lines in the file.
+
+## Running Embedded
+
+When running in embedded mode, it is not enough to add the JAR file using the `addJarDependency()` method. You must also add the JAR file to the classpath of the project. Otherwise, the 'words.jar' files file will not be found. For Standalone and Distributed modes, you only need to add the JAR file using the `addJarDependency()` method.

--- a/docs/java/java-appapi-setting-parameters.markdown
+++ b/docs/java/java-appapi-setting-parameters.markdown
@@ -1,0 +1,99 @@
+---
+layout: docs
+title:  Setting parameter values in the Java Application API
+description:  IBM Streams Java Operator Development Guide
+weight: 3
+published: true
+---
+
+The Java Application API provides the ability to invoke operators from any of the dozens of toolkits included in Streams and [available on GitHub](https://github.com/IBMStreams), regardless of whether the operator is written in Java, C++ Python, or SPL. 
+
+One of the challenges with invoking non-Java operators is setting the value for a parameter whose type does not have a direct mapping to a Java primitive type. For example, setting a parameter that expects an unsigned 32-bit integer (uint32) cannot be done using a Java primitive type since Java does not natively support unsigned numbers.
+
+Fortunately, the Java Application API provides a very simple mechanism for setting Java types to SPL types using the _SPL.createValue(T, MetaType)_ method. The following example demonstrates how to invoke the **spl.adapter::FileSink** operator. The source for this example [can be found here](https://github.com/cancilla/streamsdev/tree/master/FileSinkSample).
+
+
+~~~~~ java
+    public class Main {
+
+        public static void main(String[] args) throws Exception {
+            Topology t = new Topology("FileSink_Invoke_Sample");
+
+            // Creating source stream
+            TStream<String> src = t.strings("a", "b", "c", "d", "e");
+
+            // Converting topology stream (TStream) to SPL stream (SPLStream)
+            StreamSchema schema = Type.Factory.getStreamSchema("tuple<rstring data>");
+            SPLStream splStream = convertToSPLStream(src, schema);
+
+            // >>> Invoking FileSink Operator <<<
+            Map<String, Object> params = new HashMap<>();
+            params.put("file", "/tmp/test.txt");
+
+            SPL.invokeSink("spl.adapter::FileSink", splStream, params);
+
+            StreamsContextFactory.getStreamsContext("STANDALONE").submit(t).get();
+        }
+
+        private static SPLStream convertToSPLStream(TStream<String> tStream, StreamSchema schema) {
+            return SPLStreams.convertStream(tStream, new BiFunction<String, OutputTuple, OutputTuple>() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public OutputTuple apply(String data, OutputTuple outTuple) {
+                    outTuple.setString(0, data);
+                    return outTuple;
+                }
+
+            }, schema);
+        }
+    }
+
+~~~~~ 
+
+
+In the preceeding example, the FileSink operator is being invoked with only the **file** parameter set. The **file** parameter type is `rstring`, which directly maps to the Java `String` data type. Therefore, there is no need to use `SPL.createValue(...)`. Next, we'll look at how to set the **flush** parameter, which has a type of `uint32`. Here is the new code section for invoking the FileSink operator.
+
+
+
+~~~~ java
+    // Invoking FileSink Operator
+    Map<String, Object> params = new HashMap<>();
+    params.put("file", "/tmp/test.txt");
+    params.put("flush", SPL.createValue(1, com.ibm.streams.operator.Type.MetaType.UINT32)); // <<<< flush param
+
+    SPL.invokeSink("spl.adapter::FileSink", splStream, params);
+
+~~~~ 
+
+
+Setting the value of the parameter is done by simply calling _SPL.createValue()_ with the value you want to set and the SPL type that the parameter expects.
+
+## Setting enum parameter values
+
+There are many parameters whose values are constrained using enums. A Java `enum` type can be mapped directly to an SPL enum when setting parameter values. However, you must first create a Java enum that contains the value you plan to set. The following example shows how to set the **format** parameter when invoking the FileSink operator.
+
+
+~~~~ java
+    public class Main {
+      static enum FileSinkFormat { csv }; // <<<< define enum
+
+        public static void main(String[] args) throws Exception {
+        ...
+
+            // Invoking FileSink Operator
+            Map<String, Object> params = new HashMap<>();
+            params.put("file", "/tmp/test.txt");
+            params.put("flush", SPL.createValue(1, com.ibm.streams.operator.Type.MetaType.UINT32));
+            params.put("format", FileSinkFormat.csv); <<<< Set value using FileSinkFormat enum
+
+            SPL.invokeSink("spl.adapter::FileSink", splStream, params);
+
+        ...
+        }
+      ...
+
+~~~~
+
+
+At the class-level, we have defined an **enum** called `FileSinkFormat` that contains the value **csv**. We then use this enum value to set the parameter value before invoking the operator. **_NOTE:_** You do not need to create an enum that contains all of the possible values. The enum only needs to contain the values you plan to set for the parameter. Thanks to @dlaboss for helping to figure this out in [Issue #261](https://github.com/IBMStreams/streamsx.topology/issues/261).

--- a/index.markdown
+++ b/index.markdown
@@ -36,8 +36,7 @@ Streams Processing Language is specifically designed for creating Streams applic
 
 ### Developing Streams applications with Java
 
-{% include nav.html context="/docs/java/"%}
-
+{% include java.md%}
 
 ### Developing Streams applications with Scala
 


### PR DESCRIPTION
Migrating these two posts to be with the other docs on Java API

https://developer.ibm.com/streamsdev/2016/08/18/java-application-api-working-with-resources-in-the-app-bundle/
https://developer.ibm.com/streamsdev/2016/08/10/java-application-api-setting-parameter-values/